### PR TITLE
feat: Add `Hide feed content` patch

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/instagram/patches/distractionFree/HideFeedContentPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/instagram/patches/distractionFree/HideFeedContentPatch.kt
@@ -1,0 +1,26 @@
+package app.morphe.patches.instagram.patches.distractionFree
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patches.instagram.utility.replaceJsonFieldWithBogus
+
+private const val FEED_ITEMS_KEY = "feed_items"
+
+private object FeedContentJsonParserFingerprint : Fingerprint(
+    strings = listOf(FEED_ITEMS_KEY, "auto_load_more_enabled"),
+    name = "unsafeParseFromJson"
+)
+
+@Suppress("unused")
+val hideFeedContent = bytecodePatch(
+    name = "Hide feed content",
+    description = "Hide the feed content, leaving only stories in the home page.",
+    default = false
+) {
+    compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+    execute {
+        FeedContentJsonParserFingerprint.method.replaceJsonFieldWithBogus(FEED_ITEMS_KEY)
+    }
+}


### PR DESCRIPTION
API calls are fine, there are no additional api call made.

If you still see content, you need to clean app data to removed cached items (which are not saved in cache but inside app data).