### PR TITLE
perf: Add `JsonParserFingerprint` to handle dictionary reference in parsers

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/instagram/patches/distractionFree/HideExploreFeedPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/instagram/patches/distractionFree/HideExploreFeedPatch.kt
@@ -1,15 +1,13 @@
 package app.morphe.patches.instagram.patches.distractionFree
 
-import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patches.instagram.utility.JsonParserFingerprint
 import app.morphe.patches.instagram.utility.replaceJsonFieldWithBogus
 
-private const val EXPLORE_KEY_TO_BE_HIDDEN = "sectional_items"
-
-private object ExploreResponseJsonParserFingerprint : Fingerprint(
-    strings = listOf(EXPLORE_KEY_TO_BE_HIDDEN, "clusters"),
-    name = "unsafeParseFromJson"
+private object ExploreResponseJsonParserFingerprint : JsonParserFingerprint(
+    "sectional_items",
+    "clusters"
 )
 
 
@@ -22,6 +20,6 @@ val hideExploreFeedPatch = bytecodePatch(
     compatibleWith(COMPATIBILITY_INSTAGRAM)
 
     execute {
-        ExploreResponseJsonParserFingerprint.method.replaceJsonFieldWithBogus(EXPLORE_KEY_TO_BE_HIDDEN)
+        ExploreResponseJsonParserFingerprint.match().replaceJsonFieldWithBogus()
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/instagram/utility/JsonParserFingerprint.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/instagram/utility/JsonParserFingerprint.kt
@@ -1,0 +1,154 @@
+package app.morphe.patches.instagram.utility
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.Match
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.string
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstruction
+import app.morphe.util.indexOfFirstStringInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.SwitchPayload
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import java.util.logging.Logger
+
+private const val STRING_DICTIONARY_CLASS = "LX/000;"
+private const val STRING_DICTIONARY_METHOD = "A00"
+
+data class JsonParserMatch(
+    val method: MutableMethod,
+    val matchIndex: Int,
+    val isStringMatch: Boolean
+)
+
+internal open class JsonParserFingerprint(
+    private val mainStringKey: String,
+    private vararg val otherStringKeys: String
+) {
+    private val allStringKeys get() = listOf(mainStringKey) + otherStringKeys
+
+    context(_: BytecodePatchContext)
+    private val switchKeys get() = allStringKeys.associateWith { findSwitchKeyForString(it) }
+
+    context(_: BytecodePatchContext)
+    fun match(): JsonParserMatch = matchAll().let {
+        if (it.size > 1) {
+            Logger.getLogger(this::class.java.name)
+                .warning("SingleMatch was called but multiple fingerprints where matched")
+        }
+        it.firstOrNull()
+    } ?: throw PatchException("No match found for key: $mainStringKey")
+
+    context(_: BytecodePatchContext)
+    fun matchAll(): List<JsonParserMatch> =
+        (normalMatches() + complexMatches())
+            .distinctBy { it.method }
+
+    context(_: BytecodePatchContext)
+    private fun normalMatches(): List<JsonParserMatch> =
+        normalFingerprint.matchAllOrNull()?.mapNotNull { result ->
+            val allKeysPresent = otherStringKeys.all { key ->
+                result.method.containsKey(key, switchKeys[key])
+            }
+            if (!allKeysPresent) return@mapNotNull null
+
+            JsonParserMatch(
+                method = result.method,
+                matchIndex = normalFingerprint.stringMatches.first().index,
+                isStringMatch = true
+            )
+        } ?: emptyList()
+
+    context(_: BytecodePatchContext)
+    private fun complexMatches(): List<JsonParserMatch> {
+        // If the main key isn't in the dictionary at all, nothing to match
+        val mainSwitchKey = switchKeys[mainStringKey] ?: return emptyList()
+
+        return jsonParserFullList.mapNotNull { result ->
+            val matchIndex = result.method.indexOfFirstDictionaryCall(mainSwitchKey)
+                ?: return@mapNotNull null
+
+            // Every additional key must also be present, either way
+            val allKeysPresent = otherStringKeys.all { key ->
+                result.method.containsKey(key, switchKeys[key])
+            }
+            if (!allKeysPresent) return@mapNotNull null
+
+            JsonParserMatch(method = result.method, matchIndex = matchIndex, isStringMatch = false)
+        }
+    }
+
+    private val normalFingerprint = Fingerprint(
+        filters = listOf(string(mainStringKey)),
+        name = "unsafeParseFromJson"
+    )
+
+    context(_: BytecodePatchContext)
+    private fun findSwitchKeyForString(key: String): Int? {
+        with(stringDictionaryMethod) {
+            val offsetToSwitchKey = instructions
+                .filterIsInstance<SwitchPayload>()
+                .first()
+                .switchElements
+                .associate { it.offset to it.key }
+
+            val stringLoadIndex = indexOfFirstStringInstruction(key)
+            if (stringLoadIndex == -1) return null
+
+            var codeUnitOffset = 0
+            instructions.forEachIndexed { index, instruction ->
+                if (index == stringLoadIndex) {
+                    return offsetToSwitchKey.entries
+                        .firstOrNull { (offset, _) -> offset in (codeUnitOffset - 2)..(codeUnitOffset + 2) }
+                        ?.value
+                }
+                codeUnitOffset += instruction.codeUnits
+            }
+
+            return null
+        }
+    }
+
+
+    companion object {
+        private var _jsonParserFullList: List<Match>? = null
+
+        context(_: BytecodePatchContext)
+        private val jsonParserFullList: List<Match>
+            get() = _jsonParserFullList
+                ?: Fingerprint(name = "unsafeParseFromJson")
+                    .matchAll().also { _jsonParserFullList = it }
+
+        context(_: BytecodePatchContext)
+        private val stringDictionaryMethod: MutableMethod
+            get() = Fingerprint(
+                definingClass = STRING_DICTIONARY_CLASS,
+                name = STRING_DICTIONARY_METHOD
+            ).method
+    }
+}
+
+
+context(_: BytecodePatchContext)
+fun MutableMethod.indexOfFirstDictionaryCall(switchKey: Int): Int? {
+    if (implementation == null) return null
+
+    for (index in 1 until instructions.size) {
+        val ref = getInstruction(index).getReference<MethodReference>()
+        if (ref?.name == STRING_DICTIONARY_METHOD && ref.definingClass == STRING_DICTIONARY_CLASS) {
+            val literal = getInstruction<NarrowLiteralInstruction>(index - 1)
+            if (literal.narrowLiteral == switchKey) return index - 1
+        }
+    }
+    return null
+}
+
+context(_: BytecodePatchContext)
+private fun MutableMethod.containsKey(stringKey: String, switchKey: Int?): Boolean =
+    indexOfFirstInstruction { getReference<StringReference>()?.string == stringKey } >= 0
+            || (switchKey != null && indexOfFirstDictionaryCall(switchKey) != null)

--- a/patches/src/main/kotlin/app/morphe/patches/instagram/utility/JsonParserFingerprint.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/instagram/utility/JsonParserFingerprint.kt
@@ -11,6 +11,7 @@ import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstruction
 import app.morphe.util.indexOfFirstStringInstruction
+import app.morphe.util.indexOfFirstStringInstructionOrThrow
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.SwitchPayload
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
@@ -52,16 +53,20 @@ internal open class JsonParserFingerprint(
     context(_: BytecodePatchContext)
     private fun normalMatches(): List<JsonParserMatch> =
         normalFingerprint.matchAllOrNull()?.mapNotNull { result ->
-            val allKeysPresent = otherStringKeys.all { key ->
-                result.method.containsKey(key, switchKeys[key])
-            }
-            if (!allKeysPresent) return@mapNotNull null
+            with (result.method) {
+                val allKeysPresent = otherStringKeys.all { key ->
+                    containsKey(key, switchKeys[key])
+                }
+                if (!allKeysPresent) return@mapNotNull null
 
-            JsonParserMatch(
-                method = result.method,
-                matchIndex = normalFingerprint.stringMatches.first().index,
-                isStringMatch = true
-            )
+                val stringMatchIndex = indexOfFirstStringInstructionOrThrow(mainStringKey)
+
+                JsonParserMatch(
+                    method = this,
+                    matchIndex = stringMatchIndex,
+                    isStringMatch = true
+                )
+            }
         } ?: emptyList()
 
     context(_: BytecodePatchContext)

--- a/patches/src/main/kotlin/app/morphe/patches/instagram/utility/ReplaceJsonFieldWithBogus.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/instagram/utility/ReplaceJsonFieldWithBogus.kt
@@ -1,10 +1,38 @@
 package app.morphe.patches.instagram.utility
 
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.util.indexOfFirstStringInstructionOrThrow
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+/**
+ * Replacing the JSON key we want to skip with a random string that is not a valid JSON key.
+ * This way the feeds array will never be populated.
+ * Received JSON keys that are not handled are simply ignored, so there are no side effects.
+ */
+context(_: BytecodePatchContext)
+internal fun JsonParserMatch.replaceJsonFieldWithBogus() {
+    method.apply {
+        if (isStringMatch) {
+            val targetStringRegister = getInstruction<OneRegisterInstruction>(matchIndex).registerA
+
+            addInstruction(
+                matchIndex + 1,
+                "const-string v$targetStringRegister, \"BOGUS\"",
+            )
+        } else {
+            val targetIntRegister = getInstruction<OneRegisterInstruction>(matchIndex).registerA
+
+            addInstruction(
+                matchIndex + 1,
+                "const/4 v$targetIntRegister, 0x0",
+            )
+        }
+    }
+}
 
 internal fun MutableMethod.replaceJsonFieldWithBogus(
     key: String


### PR DESCRIPTION
So normally, an Instagram json parser is just nested if calls, where the current json key is compared with a static string:
<img width="369" height="65" alt="image" src="https://github.com/user-attachments/assets/fc549ed9-6ddf-42b2-bc62-a3e5c3e0d48b" />

However, for some unknown reason, sometimes that string is not static, but instead a dictionary where all string are collected is used:
<img width="496" height="39" alt="image" src="https://github.com/user-attachments/assets/19019e8d-a77f-4c44-a0f9-d26b686f070f" />

With this change, a `JsonParserFingerprint` can be used to handle both cases. Also handles additional strings used to fingerprint uniquely the parser.


Example of use:
<img width="555" height="201" alt="image" src="https://github.com/user-attachments/assets/83a2165b-7064-44b2-8b95-a695c916c13b" />

The string `sectional_items` suddenly was not matching anymore because `A00(3151)` was used to get that string. To fix, now use the `JsonParserFingerprint` like this:
<img width="704" height="456" alt="image" src="https://github.com/user-attachments/assets/ed0b7be3-ff51-4e1a-91f3-d74952174c2a" />


