### PR TITLE
feat(AllTrails): Enable Peak membership for 26.3.20–26.7.40

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/Constants.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/Constants.kt
@@ -46,4 +46,15 @@ object Constants {
         appIconColor = 0xFFFFFF,
         targets = listOf(AppTarget(version = "7.1.11")),
     )
+
+    val COMPATIBILITY_ALLTRAILS = Compatibility(
+        name = "AllTrails",
+        packageName = "com.alltrails.alltrails",
+        appIconColor = 0x64F67A,
+        targets = listOf(
+            AppTarget(version = "26.3.20"),
+            AppTarget(version = "26.6.20"),
+            AppTarget(version = "26.7.40", isExperimental = true),
+        ),
+    )
 }

--- a/patches/src/main/kotlin/app/morphe/patches/alltrails/pro/EnableProPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/alltrails/pro/EnableProPatch.kt
@@ -1,0 +1,84 @@
+package app.morphe.patches.alltrails.pro
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.patches.Constants
+import java.util.logging.Logger
+
+private fun MutableMethod.returnTrue() {
+    addInstructions(
+        0,
+        """
+        const/4 v0, 0x1
+        return v0
+        """.trimIndent(),
+    )
+}
+
+private fun MutableMethod.returnPeakTierString() {
+    addInstructions(
+        0,
+        """
+        const-string v0, "peak"
+        return-object v0
+        """.trimIndent(),
+    )
+}
+
+@Suppress("unused")
+val enablePremiumPatch = bytecodePatch(
+    name = "Enable Peak membership",
+    description = "Enables some app features locked behind the subscription paywall. " +
+        "Not all premium functionality is available. " +
+        "26.7.40 uses an additional user-data delegate hook alongside the Gson User model.",
+) {
+    compatibleWith(Constants.COMPATIBILITY_ALLTRAILS)
+
+    execute {
+        val logger = Logger.getLogger("EnableProPatch")
+        var applied = 0
+
+        fun tryHook(label: String, method: MutableMethod?, block: (MutableMethod) -> Unit) {
+            if (method == null) {
+                logger.warning("Could not find $label; skipping")
+                return
+            }
+            if (method.implementation == null) {
+                logger.warning("Skipping $label: method has no implementation")
+                return
+            }
+            try {
+                block(method)
+                applied++
+                logger.info("Applied Peak hook: $label")
+            } catch (e: Exception) {
+                logger.warning("Failed to apply $label: ${e.message}")
+            }
+        }
+
+        tryHook("User.isPro", IsProFingerprint.methodOrNull) { it.returnTrue() }
+        tryHook("User.getSubscriptionTier", GetSubscriptionTierFingerprint.methodOrNull) {
+            it.returnPeakTierString()
+        }
+
+        tryHook("UserDataDelegate.subscriptionInfo", Cb60SubscriptionInfoFingerprint.methodOrNull) {
+            it.addInstructions(
+                0,
+                """
+                sget-object v0, Lps10${'$'}d${'$'}c;->INSTANCE:Lps10${'$'}d${'$'}c;
+                const/4 v1, 0x0
+                const/4 v2, 0x0
+                const/4 v3, 0x0
+                new-instance v4, Lab60${'$'}a;
+                invoke-direct {v4, v0, v1, v2, v3}, Lab60${'$'}a;-><init>(Lps10;ZZZ)V
+                return-object v4
+                """.trimIndent(),
+            )
+        }
+
+        if (applied == 0) {
+            error("Enable Peak membership: no hooks applied")
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/alltrails/pro/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/alltrails/pro/Fingerprints.kt
@@ -1,0 +1,24 @@
+package app.morphe.patches.alltrails.pro
+
+import app.morphe.patcher.Fingerprint
+
+/** Gson User model (`Lgb60;` on 26.6.20, `Lw860;` on 26.7.40). */
+object IsProFingerprint : Fingerprint(
+    name = "isPro",
+    returnType = "Z",
+)
+
+object GetSubscriptionTierFingerprint : Fingerprint(
+    name = "getSubscriptionTier",
+    returnType = "Ljava/lang/String;",
+)
+
+/**
+ * 26.7.40 account delegate. Feature gates call subscription info built from
+ * protobuf user data — bypass it and return Peak tier directly.
+ */
+internal object Cb60SubscriptionInfoFingerprint : Fingerprint(
+    definingClass = "Lcb60;",
+    name = "z",
+    returnType = "Lab60\$a;",
+)


### PR DESCRIPTION
## Summary
- Adds **Enable Peak membership** for AllTrails (`com.alltrails.alltrails`).
- Supported versions: **26.3.20**, **26.6.20**, and experimental **26.7.40**.
- Hooks the Gson User model (`isPro`, `getSubscriptionTier`) on all supported builds.
- On **26.7.40**, also hooks the user-data delegate (`cb60.z()`) so Peak-gated features work — that build routes subscription checks through protobuf user data, not the Gson model alone.
- Fails the patch if no hooks apply (avoids silent no-ops).

Adapted from [Luen/morphe-patches](https://github.com/Luen/morphe-patches) to match this repo's `app.morphe.patches` layout.

## Test plan
- [x] `./gradlew :patches:compileKotlin` passes
- [ ] Patch AllTrails 26.6.20 and confirm Peak UI unlocks
- [ ] Patch AllTrails 26.7.40 (experimental) and confirm Peak UI unlocks

Made with [Cursor](https://cursor.com)